### PR TITLE
GH-1 Marketo block

### DIFF
--- a/blocks/marketo/marketo.css
+++ b/blocks/marketo/marketo.css
@@ -1,0 +1,3 @@
+.marketo {
+  min-height: 216px;
+}

--- a/blocks/marketo/marketo.js
+++ b/blocks/marketo/marketo.js
@@ -1,0 +1,34 @@
+import { loadScript } from '../../scripts/aem.js';
+
+// <script src="//407-SHS-468.mktoweb.com/js/forms2/js/forms2.min.js"></script>
+// <form id="mktoForm_1005"></form> <script>MktoForms2.loadForm("//407-SHS-468.mktoweb.com", "407-SHS-468", 1005);</script>
+
+function getFormProps(href) {
+  try {
+    const { searchParams, hash } = new URL(href);
+    const munchkinId = searchParams.get('munchkinId');
+    const formId = hash.split('/').pop();
+    return {
+      munchkinId,
+      formId,
+      baseUrl: `//${munchkinId}.mktoweb.com`,
+      baseFormSrc: `//${munchkinId}.mktoweb.com/js/forms2/js/forms2.min.js`,
+    };
+  } catch (e) {
+    throw Error('Could not create script source from URL.');
+  }
+}
+
+export default async function decorate(block) {
+  // Link format: https://engage-ab.marketo.com/?munchkinId=407-SHS-468#/ds/mktform/1005
+  const href = block.innerText.trim();
+  const { munchkinId, formId, baseUrl, baseFormSrc } = getFormProps(href);
+  await loadScript(baseFormSrc);
+  block.innerHTML = '';
+  if (!window.MktoForms2) return;
+
+  const form = document.createElement('form');
+  form.id = `mktoForm_${formId}`;
+  block.append(form);
+  window.MktoForms2.loadForm(baseUrl, munchkinId, formId);
+}


### PR DESCRIPTION
* Ability to paste the URL directly from Marketo

Fix #1

Test URLs:
- Before: https://main--sas-demo--auniverseaway.aem.live/drafts/cmillar/marketo
- After: https://marketo--sas-demo--auniverseaway.aem.live/drafts/cmillar/marketo
